### PR TITLE
Fixed item ids

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -555,7 +555,7 @@ class ApiRequestHandler(http.server.BaseHTTPRequestHandler):
                     self.send_response(404)
                     self.end_headers()
         elif path[0] == "items":
-            item_id = int(path[1])
+            item_id = path[1]
             content_length = int(self.headers["Content-Length"])
             post_data = self.rfile.read(content_length)
             updated_item = json.loads(post_data.decode())
@@ -727,7 +727,7 @@ class ApiRequestHandler(http.server.BaseHTTPRequestHandler):
             self.send_response(200)
             self.end_headers()
         elif path[0] == "items":
-            item_id = int(path[1])
+            item_id = path[1]
             data_provider.fetch_item_pool().remove_item(item_id)
             data_provider.fetch_item_pool().save()
             self.send_response(200)

--- a/api/models/items.py
+++ b/api/models/items.py
@@ -16,7 +16,7 @@ class Items(Base):
 
     def get_item(self, item_id):
         for x in self.data:
-            if x["id"] == item_id:
+            if x["uid"] == item_id:
                 return x
         return None
 
@@ -56,13 +56,13 @@ class Items(Base):
     def update_item(self, item_id, item):
         item["updated_at"] = self.get_timestamp()
         for i in range(len(self.data)):
-            if self.data[i]["id"] == item_id:
+            if self.data[i]["uid"] == item_id:
                 self.data[i] = item
                 break
 
     def remove_item(self, item_id):
         for x in self.data:
-            if x["id"] == item_id:
+            if x["uid"] == item_id:
                 self.data.remove(x)
 
     def load(self, is_debug):


### PR DESCRIPTION
This pull request includes changes to the `api/main.py` and `api/models/items.py` files to standardize the use of the `item_id` field, replacing it with `uid` in the models and removing unnecessary type conversions in the API handlers.

Standardization of item identifiers:

* [`api/models/items.py`](diffhunk://#diff-faff49c19f7e7fc9b3f60ed6e865a2ec5c38e929548e01557ecbe33b825373ccL19-R19): Changed the item identifier from `id` to `uid` in the `get_item`, `update_item`, and `remove_item` methods. [[1]](diffhunk://#diff-faff49c19f7e7fc9b3f60ed6e865a2ec5c38e929548e01557ecbe33b825373ccL19-R19) [[2]](diffhunk://#diff-faff49c19f7e7fc9b3f60ed6e865a2ec5c38e929548e01557ecbe33b825373ccL59-R65)

Simplification of API handlers:

* [`api/main.py`](diffhunk://#diff-c2c3b0c64a2690193a471cfc8068fcb622a23e1b4323c693b6ba20835f26fb88L558-R558): Removed unnecessary type conversion for `item_id` in the `handle_put_version_1` and `handle_delete_version_1` methods. [[1]](diffhunk://#diff-c2c3b0c64a2690193a471cfc8068fcb622a23e1b4323c693b6ba20835f26fb88L558-R558) [[2]](diffhunk://#diff-c2c3b0c64a2690193a471cfc8068fcb622a23e1b4323c693b6ba20835f26fb88L730-R730)