### PR TITLE
63 rename never existing id to non existing

### DIFF
--- a/tests/integration/test_integration_items.py
+++ b/tests/integration/test_integration_items.py
@@ -90,7 +90,7 @@ def test_get_item_by_id(client):
 
 
 def test_get_nonexistent_item(client):
-    response = client.get('/items/'+non_existent_id, headers=test_headers)
+    response = client.get('/items/' + str(non_existent_id), headers=test_headers)
     assert response.status_code == 404
 
 
@@ -117,7 +117,7 @@ def test_update_item_invalid_api_key(client):
 def test_update_item_no_item(client):
     updated_item = test_item.copy()
     updated_item['code'] = 'updated_code'
-    response = client.put('/items/' + non_existent_id, json=updated_item, headers=test_headers)
+    response = client.put('/items/' + str(non_existent_id), json=updated_item, headers=test_headers)
     assert response.status_code == 404
 
 
@@ -146,7 +146,7 @@ def test_delete_item_invalid_api_key(client):
 
 
 def test_delete_item_no_item(client):
-    response = client.delete('/items/' + non_existent_id, headers=test_headers)
+    response = client.delete('/items/' + str(non_existent_id), headers=test_headers)
     assert response.status_code == 404
     response_get_item = client.get('/items/' + test_item['uid'], headers=test_headers)
     assert response_get_item.status_code == 200

--- a/tests/integration/test_integration_shipments.py
+++ b/tests/integration/test_integration_shipments.py
@@ -106,7 +106,7 @@ def test_get_invalid_shipment_id(client):
 
 
 def test_get_nonexistent_shipment(client):
-    response = client.get('/shipments/'+non_existent_id, headers=test_headers)
+    response = client.get('/shipments/' + str(non_existent_id), headers=test_headers)
     assert response.status_code == 404
 
 
@@ -140,7 +140,7 @@ def test_update_invalid_shipment_id(client):
 def test_update_nonexistent_shipment(client):
     updated_shipment = test_shipment.copy()
     updated_shipment['shipment_status'] = 'Shipped'
-    response = client.put('/shipments/'+non_existent_id, json=updated_shipment, headers=test_headers)
+    response = client.put('/shipments/' + str(non_existent_id), json=updated_shipment, headers=test_headers)
     assert response.status_code == 404
 
 

--- a/tests/integration/test_integration_warehouses.py
+++ b/tests/integration/test_integration_warehouses.py
@@ -45,7 +45,7 @@ def test_get_all_warehouses_invalid_api_key(client):
 
 def test_add_warehouse(client):
     response = client.post("/warehouses/", json=test_data, headers=test_headers)
-    assert response.status_code == 200
+    assert response.status_code == 201 or response.status_code == 200
 
 
 def test_add_warehouse_no_api_key(client):


### PR DESCRIPTION
This pull request includes several changes to the integration tests for items, shipments, and warehouses. The main focus is on improving the handling of non-existent IDs and updating response status code assertions.

Changes to integration tests for items:

* [`tests/integration/test_integration_items.py`](diffhunk://#diff-0c2c9b031d18f40d0a0adff6192ebfa3def07f5d1dae97b401813b0d15a107b1L93-R93): Updated the tests to use `str(non_existent_id)` instead of `never_existing_id` for better clarity and consistency. [[1]](diffhunk://#diff-0c2c9b031d18f40d0a0adff6192ebfa3def07f5d1dae97b401813b0d15a107b1L93-R93) [[2]](diffhunk://#diff-0c2c9b031d18f40d0a0adff6192ebfa3def07f5d1dae97b401813b0d15a107b1L120-R120) [[3]](diffhunk://#diff-0c2c9b031d18f40d0a0adff6192ebfa3def07f5d1dae97b401813b0d15a107b1L149-R149)

Changes to integration tests for shipments:

* [`tests/integration/test_integration_shipments.py`](diffhunk://#diff-5f2086c273480b4257bb57cd23234fd3e25f38605124a2ff1e24a732f57e69a8L109-R109): Modified the tests to use `str(non_existent_id)` instead of `never_existing_id` to improve readability and consistency. [[1]](diffhunk://#diff-5f2086c273480b4257bb57cd23234fd3e25f38605124a2ff1e24a732f57e69a8L109-R109) [[2]](diffhunk://#diff-5f2086c273480b4257bb57cd23234fd3e25f38605124a2ff1e24a732f57e69a8L143-R143)

Changes to integration tests for warehouses:

* [`tests/integration/test_integration_warehouses.py`](diffhunk://#diff-a8625d9b2611ee2ea40301c0a840525ada85b170d388802dcc5e3e8ae0770165L48-R48): Adjusted the assertion to check for both `201` and `200` status codes when adding a warehouse.