### PR TITLE
Fixed bug of update items on order

### DIFF
--- a/api/models/orders.py
+++ b/api/models/orders.py
@@ -64,16 +64,17 @@ class Orders(Base):
             if not found:
                 inventories = data_provider.fetch_inventory_pool().get_inventories_for_item(current_item["item_id"])
                 min_ordered = float("inf")
-                min_inventory
+                min_inventory = None;
 
                 for inv in inventories:
                     if inv["total_allocated"] > min_ordered:
                         min_ordered = inv["total_allocated"]
                         min_inventory = inv
 
-                min_inventory["total_allocated"] -= current_item["amount"]
-                min_inventory["total_expected"] = updated_item["total_on_hand"] + updated_item["total_ordered"]
-                data_provider.fetch_inventory_pool().update_inventory(min_inventory["id"], min_inventory)
+                if min_inventory:
+                    min_inventory["total_allocated"] -= current_item["amount"]
+                    min_inventory["total_expected"] = min_inventory["total_on_hand"] + min_inventory["total_ordered"]
+                    data_provider.fetch_inventory_pool().update_inventory(min_inventory["id"], min_inventory)
 
         for updated_item in items:
             found = False
@@ -98,7 +99,7 @@ class Orders(Base):
                 if min_inventory:
                     delta_amount = updated_item["amount"] - matching_current_item["amount"]
                     min_inventory["total_allocated"] += delta_amount
-                    min_inventory["total_expected"] = updated_item["total_on_hand"] + updated_item["total_ordered"]
+                    min_inventory["total_expected"] = min_inventory["total_on_hand"] + min_inventory["total_ordered"]
                     data_provider.fetch_inventory_pool().update_inventory(min_inventory["id"], min_inventory)
 
         order["items"] = items


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/dc365051-ea6f-4a0c-b0cd-2c82b86fb7f9)
This pull request includes changes to the `update_items_in_order` method in the `api/models/orders.py` file to fix a bug and improve inventory handling. The most important changes include initializing `min_inventory` to `None` and adding a check before updating inventory fields.

Bug Fixes and Improvements:

* [`api/models/orders.py`](diffhunk://#diff-f6b41e636c0278e1c89174fccaab4d039d0f9e8ab0da948ba19cdde9648a9febL67-R76): Initialized `min_inventory` to `None` to prevent potential reference errors.
* [`api/models/orders.py`](diffhunk://#diff-f6b41e636c0278e1c89174fccaab4d039d0f9e8ab0da948ba19cdde9648a9febL67-R76): Added a check to ensure `min_inventory` is not `None` before updating `total_expected` and other inventory fields. [[1]](diffhunk://#diff-f6b41e636c0278e1c89174fccaab4d039d0f9e8ab0da948ba19cdde9648a9febL67-R76) [[2]](diffhunk://#diff-f6b41e636c0278e1c89174fccaab4d039d0f9e8ab0da948ba19cdde9648a9febL101-R102)