### PR TITLE
Add endpoint to retrieve client orders

### DIFF
--- a/api/Controllers/ClientController.py
+++ b/api/Controllers/ClientController.py
@@ -21,6 +21,17 @@ def read_clients(api_key: str = Depends(auth_provider.get_api_key)):
         raise HTTPException(status_code=404, detail="No clients found")
     return clients
 
+@client_router.get("/{client_id}/orders")
+def read_client_orders(client_id: int, api_key: str = Depends(auth_provider.get_api_key)):
+    data_provider.init()
+    client = data_provider.fetch_client_pool().get_client(client_id)
+    if client is None:
+        raise HTTPException(status_code=404, detail="Client not found")
+    orders = data_provider.fetch_order_pool().get_orders_for_client(client_id)
+    if orders is None:
+        raise HTTPException(status_code=404, detail="No orders found for client")
+    return orders
+
 
 @client_router.post("/")
 def create_client(client: dict, api_key: str = Depends(auth_provider.get_api_key)):

--- a/tests/integration/test_integration_clients.py
+++ b/tests/integration/test_integration_clients.py
@@ -79,6 +79,27 @@ def test_get_nonexistent_CargoClient(client):
     response = client.get('/clients/' + str(non_existent_id), headers=test_headers)
     assert response.status_code == 404
 
+def test_get_orders_for_client(client):
+    response = client.get(f'/clients/{test_CargoClient["id"]}/orders', headers=test_headers)
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)
+
+def test_get_orders_for_nonexistent_client(client):
+    response = client.get(f'/clients/{non_existent_id}/orders', headers=test_headers)
+    assert response.status_code == 404
+
+def test_get_orders_for_client_invalid_client_id(client):
+    response = client.get('/clients/invalid_id/orders', headers=test_headers)
+    assert response.status_code == 422
+
+def test_get_orders_for_client_no_api_key(client):
+    response = client.get(f'/clients/{test_CargoClient["id"]}/orders')
+    assert response.status_code == 403
+
+def test_get_orders_for_client_invalid_api_key(client):
+    response = client.get(f'/clients/{test_CargoClient["id"]}/orders', headers=invalid_headers)
+    assert response.status_code == 403
+
 def test_update_CargoClient_no_api_key(client):
     updated_CargoClient = test_CargoClient.copy()
     updated_CargoClient['name'] = 'Updated Inc'


### PR DESCRIPTION
This pull request introduces a new endpoint to fetch orders for a specific client and includes corresponding integration tests to ensure the new functionality works correctly. The most important changes include adding the new endpoint in the `ClientController` and creating multiple test cases to cover different scenarios for this endpoint.

### New Endpoint for Client Orders:

* [`api/Controllers/ClientController.py`](diffhunk://#diff-70b1957b8900b9ac80ea15bb11bdf29a321ad7e6638dd0bbb6ca3002e839192eR24-R34): Added a new endpoint `read_client_orders` to fetch orders for a specific client. This endpoint initializes the data provider, fetches the client and their orders, and handles cases where the client or orders are not found.

### Integration Tests for New Endpoint:

* `tests/integration/test_integration_clients.py`: Added several test cases to verify the new endpoint's functionality, including:
  - Fetching orders for an existing client.
  - Handling a nonexistent client.
  - Handling an invalid client ID.
  - Handling requests without an API key.
  - Handling requests with an invalid API key.