### PR TITLE
Add partial update functionality for warehouses and update response h…

### DIFF
--- a/tests/integration/v2/test_integration_warehouses_v2.py
+++ b/tests/integration/v2/test_integration_warehouses_v2.py
@@ -226,6 +226,59 @@ def test_update_invalid_warehouse_id(client):
     assert response.status_code == 422
 
 
+def test_partial_update_warehouse(client):
+    updated_warehouse = {"name": "Updated Warehouse"}
+    response = client.patch(
+        "/warehouses/" + str(test_warehouse["id"]),
+        json=updated_warehouse,
+        headers=test_headers,
+    )
+    assert response.status_code == 200
+    response_get = client.get(
+        "/warehouses/" + str(test_warehouse["id"]), headers=test_headers
+    )
+    assert response_get.status_code == 200
+    response_json = response_get.json()
+    assert response_json is not None
+    assert response_json["name"] == updated_warehouse["name"]
+
+
+def test_partial_update_warehouse_no_api_key(client):
+    updated_warehouse = {"name": "Updated Warehouse"}
+    response = client.patch(
+        "/warehouses/" + str(test_warehouse["id"]), json=updated_warehouse
+    )
+    assert response.status_code == 403
+
+
+def test_partial_update_warehouse_invalid_api_key(client):
+    updated_warehouse = {"name": "Updated Warehouse"}
+    response = client.patch(
+        "/warehouses/" + str(test_warehouse["id"]),
+        json=updated_warehouse,
+        headers=invalid_headers,
+    )
+    assert response.status_code == 403
+
+
+def test_partial_update_nonexistent_warehouse(client):
+    updated_warehouse = {"name": "Updated Warehouse"}
+    response = client.patch(
+        "/warehouses/" + str(non_existent_id),
+        json=updated_warehouse,
+        headers=test_headers,
+    )
+    assert response.status_code == 404
+
+
+def test_partial_update_invalid_warehouse_id(client):
+    updated_warehouse = {"name": "Updated Warehouse"}
+    response = client.patch(
+        "/warehouses/invalid_id", json=updated_warehouse, headers=test_headers
+    )
+    assert response.status_code == 422
+
+
 def test_delete_warehouse(client):
     response = client.delete(
         "/warehouses/" + str(test_warehouse["id"]), headers=test_headers


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to the warehouse endpoint in the API, including the addition of a new partial update functionality and corresponding tests.

### Enhancements to the warehouse endpoint:

* [`app/api/v2/endpoints/warehouse.py`](diffhunk://#diff-99cace830bed11740be0d74c4c5b17f6e5fe11506431dd2e7672bd0307ca3d8aL76-R105): Added a new endpoint `partial_update_warehouse` to allow partial updates to warehouse records.

### Improvements to existing methods:

* [`app/api/v2/endpoints/warehouse.py`](diffhunk://#diff-99cace830bed11740be0d74c4c5b17f6e5fe11506431dd2e7672bd0307ca3d8aL57-R60): Modified `create_warehouse` and `update_warehouse` to return the created or updated warehouse object instead of the input data. [[1]](diffhunk://#diff-99cace830bed11740be0d74c4c5b17f6e5fe11506431dd2e7672bd0307ca3d8aL57-R60) [[2]](diffhunk://#diff-99cace830bed11740be0d74c4c5b17f6e5fe11506431dd2e7672bd0307ca3d8aL76-R105)

### Testing additions:

* [`tests/integration/v2/test_integration_warehouses_v2.py`](diffhunk://#diff-4c890cb93675cd441c5c6f79f567e1d96394132f6e7277469741bc0fe1e32c60R229-R281): Added multiple tests for the new `partial_update_warehouse` endpoint, including tests for successful updates, updates without API key, updates with invalid API key, updates to nonexistent warehouses, and updates with invalid warehouse IDs.…andling