### PR TITLE
Add partial update endpoint for transfers and corresponding tests

### DIFF
--- a/app/api/v2/endpoints/transfer.py
+++ b/app/api/v2/endpoints/transfer.py
@@ -68,6 +68,27 @@ def update_transfer(
     return updated_transfer
 
 
+@transfer_router_v2.patch("/{transfer_id}")
+def partial_update_transfer(
+    transfer_id: int,
+    transfer: dict,
+    api_key: str = Depends(auth_provider.get_api_key),
+):
+    data_provider_v2.init()
+    existing_transfer = data_provider_v2.fetch_transfer_pool().get_transfer(transfer_id)
+    if existing_transfer is None:
+        raise HTTPException(status_code=404, detail="Transfer not found")
+
+    for key, value in transfer.items():
+        setattr(existing_transfer, key, value)
+
+    partial_updated_transfer = data_provider_v2.fetch_transfer_pool().update_transfer(
+        transfer_id, existing_transfer
+    )
+    data_provider_v2.fetch_transfer_pool().save()
+    return partial_updated_transfer
+
+
 @transfer_router_v2.put("/{transfer_id}/commit")
 def commit_transfer(
     transfer_id: int, api_key: str = Depends(auth_provider.get_api_key)

--- a/tests/integration/v2/test_integration_transfers_v2.py
+++ b/tests/integration/v2/test_integration_transfers_v2.py
@@ -113,32 +113,45 @@ def test_get_transfer_items_invalid_api_key(client):
 
 
 def test_update_transfer(client):
+    updated_item_group = test_transfer.copy()
+    updated_item_group["reference"] = "TR00002"
     response = client.put(
         "/transfers/" + str(test_transfer["id"]),
-        json=test_transfer,
+        json=updated_item_group,
         headers=test_headers,
     )
     assert response.status_code == 200
     assert response.json()["id"] == test_transfer["id"]
+    assert response.json()["reference"] == "TR00002"
 
 
 def test_update_transfer_no_api_key(client):
-    response = client.put("/transfers/" + str(test_transfer["id"]), json=test_transfer)
+    updated_item_group = test_transfer.copy()
+    updated_item_group["reference"] = "TR00002"
+    response = client.put(
+        "/transfers/" + str(test_transfer["id"]), json=updated_item_group
+    )
     assert response.status_code == 403
 
 
 def test_update_transfer_invalid_api_key(client):
+    updated_item_group = test_transfer.copy()
+    updated_item_group["reference"] = "TR00002"
     response = client.put(
         "/transfers/" + str(test_transfer["id"]),
-        json=test_transfer,
+        json=updated_item_group,
         headers=invalid_headers,
     )
     assert response.status_code == 403
 
 
 def test_update_non_existent_transfer(client):
+    updated_item_group = test_transfer.copy()
+    updated_item_group["reference"] = "TR00002"
     response = client.put(
-        "/transfers/" + str(non_existent_id), json=test_transfer, headers=test_headers
+        "/transfers/" + str(non_existent_id),
+        json=updated_item_group,
+        headers=test_headers,
     )
     assert response.status_code == 404
     response_json = response.json()
@@ -147,8 +160,55 @@ def test_update_non_existent_transfer(client):
 
 
 def test_update_invalid_transfer_id(client):
+    updated_item_group = test_transfer.copy()
+    updated_item_group["reference"] = "TR00002"
     response = client.put(
-        "/transfers/invalid_id", json=test_transfer, headers=test_headers
+        "/transfers/invalid_id", json=updated_item_group, headers=test_headers
+    )
+    assert response.status_code == 422
+
+
+def test_partial_update_transfer(client):
+    response = client.patch(
+        "/transfers/" + str(test_transfer["id"]),
+        json={"reference": "TR00002"},
+        headers=test_headers,
+    )
+    assert response.status_code == 200
+    assert response.json()["reference"] == "TR00002"
+
+
+def test_partial_update_transfer_no_api_key(client):
+    response = client.patch(
+        "/transfers/" + str(test_transfer["id"]), json={"reference": "TR00002"}
+    )
+    assert response.status_code == 403
+
+
+def test_partial_update_transfer_invalid_api_key(client):
+    response = client.patch(
+        "/transfers/" + str(test_transfer["id"]),
+        json={"reference": "TR00002"},
+        headers=invalid_headers,
+    )
+    assert response.status_code == 403
+
+
+def test_partial_update_non_existent_transfer(client):
+    response = client.patch(
+        "/transfers/" + str(non_existent_id),
+        json={"reference": "TR00002"},
+        headers=test_headers,
+    )
+    assert response.status_code == 404
+    response_json = response.json()
+    assert response_json is not None
+    assert response_json["detail"] == "Transfer not found"
+
+
+def test_partial_update_invalid_transfer_id(client):
+    response = client.patch(
+        "/transfers/invalid_id", json={"reference": "TR00002"}, headers=test_headers
     )
     assert response.status_code == 422
 


### PR DESCRIPTION
This pull request introduces a new endpoint for partial updates to transfers and adds corresponding tests. The most important changes include the addition of the `partial_update_transfer` function and several new test cases to ensure proper functionality.

### New Endpoint for Partial Updates:

* [`app/api/v2/endpoints/transfer.py`](diffhunk://#diff-e6bca7bf4ee8e45139805fb26cb7a4698e05e84efaa24774f3c827b0ff4039b6R71-R91): Added the `partial_update_transfer` function to handle PATCH requests for updating specific fields of a transfer.

### Corresponding Tests:

* [`tests/integration/v2/test_integration_transfers_v2.py`](diffhunk://#diff-d8df44d4905775f4d2a5988f758b90dc53c3039da5f7a870a788401992f5d4ecR163-R211): Added test cases for `partial_update_transfer` to verify successful updates, handling of missing API keys, invalid API keys, non-existent transfers, and invalid transfer IDs.

### Updates to Existing Tests:

* [`tests/integration/v2/test_integration_transfers_v2.py`](diffhunk://#diff-d8df44d4905775f4d2a5988f758b90dc53c3039da5f7a870a788401992f5d4ecR116-R154): Modified existing test cases for `update_transfer` to use an updated item group with a new reference value.