### PR TITLE
Add partial update endpoint for items and corresponding tests

### DIFF
--- a/tests/integration/v2/test_integration_items_v2.py
+++ b/tests/integration/v2/test_integration_items_v2.py
@@ -222,6 +222,44 @@ def test_update_item(client):
     assert response_get_item.json()["code"] == updated_item["code"]
 
 
+def test_partial_update_item_no_api_key(client):
+    updated_item = {"code": "updated_code"}
+    response = client.patch("/items/" + test_item["uid"], json=updated_item)
+    assert response.status_code == 403
+
+
+def test_partial_update_item_invalid_api_key(client):
+    updated_item = {"code": "updated_code"}
+    response = client.patch(
+        "/items/" + test_item["uid"], json=updated_item, headers=invalid_headers
+    )
+    assert response.status_code == 403
+
+
+def test_partial_update_item_no_item(client):
+    updated_item = {"code": "updated_code"}
+    response = client.patch(
+        "/items/" + str(non_existent_id), json=updated_item, headers=test_headers
+    )
+    assert response.status_code == 404
+
+
+def test_partial_update_item(client):
+    updated_item = {"code": "updated_code"}
+
+    response = client.post("/items/", json=test_item, headers=test_headers)
+    assert response.status_code == 201
+    test_item["uid"] = response.json()["uid"]
+
+    response = client.patch(
+        "/items/" + test_item["uid"], json=updated_item, headers=test_headers
+    )
+    assert response.status_code == 200
+    response_get_item = client.get("/items/" + test_item["uid"], headers=test_headers)
+    assert response_get_item.status_code == 200
+    assert response_get_item.json()["code"] == updated_item["code"]
+
+
 def test_delete_item_no_api_key(client):
     response = client.delete("/items/" + test_item["uid"])
     assert response.status_code == 403


### PR DESCRIPTION
This pull request introduces a new endpoint for partial updates to items and adds corresponding integration tests. It also includes a minor formatting change in the `create_item` function.

### New Endpoint for Partial Updates:
* Added `partial_update_item` function to handle PATCH requests for updating specific fields of an item (`app/api/v2/endpoints/item.py`).

### Integration Tests:
* Added multiple tests for the new `partial_update_item` endpoint to cover scenarios such as no API key, invalid API key, non-existent item, and successful partial update (`tests/integration/v2/test_integration_items_v2.py`).

### Minor Formatting Change:
* Reformatted the return statement in the `create_item` function for better readability (`app/api/v2/endpoints/item.py`).