### PR TITLE
Add partial update endpoint for item lines with corresponding tests

### DIFF
--- a/tests/integration/v2/test_integration_item_lines_v2.py
+++ b/tests/integration/v2/test_integration_item_lines_v2.py
@@ -260,6 +260,59 @@ def test_update_item_line(client):
     )
 
 
+def test_partial_update_item_line_no_api_key(client):
+    updated_item_line = {"description": "updated item line"}
+    response = client.patch(
+        "/item_lines/" + str(test_item_line["id"]), json=updated_item_line
+    )
+    assert response.status_code == 403
+
+
+def test_partial_update_item_line_invalid_api_key(client):
+    updated_item_line = {"description": "updated item line"}
+    response = client.patch(
+        "/item_lines/" + str(test_item_line["id"]),
+        json=updated_item_line,
+        headers=invalid_headers,
+    )
+    assert response.status_code == 403
+
+
+def test_partial_update_item_line_invalid_id(client):
+    updated_item_line = {"description": "updated item line"}
+    response = client.patch(
+        "/item_lines/invalid_id", json=updated_item_line, headers=test_headers
+    )
+    assert response.status_code == 422
+
+
+def test_partial_update_item_line_non_existent_id(client):
+    updated_item_line = {"description": "updated item line"}
+    response = client.patch(
+        "/item_lines/" + str(non_existent_id),
+        json=updated_item_line,
+        headers=test_headers,
+    )
+    assert response.status_code == 404
+
+
+def test_partial_update_item_line(client):
+    updated_item_line = {"description": "updated item line"}
+    response = client.patch(
+        "/item_lines/" + str(test_item_line["id"]),
+        json=updated_item_line,
+        headers=test_headers,
+    )
+    assert response.status_code == 200
+    response_get_item_line = client.get(
+        "/item_lines/" + str(test_item_line["id"]), headers=test_headers
+    )
+    assert response_get_item_line.status_code == 200
+    assert (
+        response_get_item_line.json()["description"] == updated_item_line["description"]
+    )
+
+
 def test_delete_item_line_no_api_key(client):
     response = client.delete("/item_lines/" + str(test_item_line["id"]))
     assert response.status_code == 403


### PR DESCRIPTION
This pull request introduces a new feature for partially updating item lines and includes related refactoring and tests. The most important changes include adding a new endpoint for partial updates, refactoring existing code for better readability, and adding comprehensive tests for the new functionality.

### New Feature: Partial Update for Item Lines
* [`app/api/v2/endpoints/item_line.py`](diffhunk://#diff-7a0974116749f0e70eb6a8488b82ebce5fbd1c247f2af71620b079496329376aL76-R112): Added a new `partial_update_item_line` endpoint to allow partial updates to item lines.

### Refactoring for Readability
* [`app/api/v2/endpoints/item_line.py`](diffhunk://#diff-7a0974116749f0e70eb6a8488b82ebce5fbd1c247f2af71620b079496329376aL54-R61): Refactored the `create_item` and `update_item` functions to improve readability by reformatting the code. [[1]](diffhunk://#diff-7a0974116749f0e70eb6a8488b82ebce5fbd1c247f2af71620b079496329376aL54-R61) [[2]](diffhunk://#diff-7a0974116749f0e70eb6a8488b82ebce5fbd1c247f2af71620b079496329376aL76-R112)

### Tests for Partial Update Functionality
* [`tests/integration/v2/test_integration_item_lines_v2.py`](diffhunk://#diff-81fad9d382f36ccb2933e91b06a539f06cab9b73e2bf3a028f02be5d7fd83975R263-R315): Added tests for the `partial_update_item_line` endpoint, including cases for no API key, invalid API key, invalid ID, non-existent ID, and successful updates.