### PR TITLE
214 - refactor: update integration tests for item groups, item lines, item …

### DIFF
--- a/tests/integration/v2/test_integration_item_groups_v2.py
+++ b/tests/integration/v2/test_integration_item_groups_v2.py
@@ -113,18 +113,6 @@ def test_get_nonexistent_item_group(client):
     assert response.status_code == 404
 
 
-def test_get_items_for_item_group(client):
-    response = client.get(
-        f"/item_groups/{test_item_group['id']}/items", headers=test_headers
-    )
-    assert response.status_code == 200
-
-
-def test_get_items_for_nonexistent_item_group(client):
-    response = client.get(f"/item_groups/{non_existent_id}/items", headers=test_headers)
-    assert response.status_code == 404
-
-
 def test_get_items_for_invalid_item_group_id(client):
     response = client.get("/item_groups/invalid_id/items", headers=test_headers)
     assert response.status_code == 422
@@ -295,6 +283,18 @@ def test_delete_item_group_invalid_api_key(client):
         "/item_groups/" + str(test_item_group["id"]), headers=test_headers
     )
     assert response_get_item_group.status_code == 200
+
+
+def test_delete_item_group_invalid_id(client):
+    response = client.delete("/item_groups/invalid_id", headers=test_headers)
+    assert response.status_code == 422
+
+
+def test_delete_nonexistent_item_group(client):
+    response = client.delete(
+        "/item_groups/" + str(non_existent_id), headers=test_headers
+    )
+    assert response.status_code == 404
 
 
 def test_delete_item_group(client):

--- a/tests/integration/v2/test_integration_item_lines_v2.py
+++ b/tests/integration/v2/test_integration_item_lines_v2.py
@@ -152,6 +152,13 @@ def test_get_item_line_items_invalid_id(client):
     assert response.status_code == 422
 
 
+def test_get_items_for_item_line_not_found(client):
+    response = client.get(
+        "/item_lines/" + str(non_existent_id) + "/items", headers=test_headers
+    )
+    assert response.status_code == 404
+
+
 def test_get_item_line_items(client):
     response_post_fake_item_1 = client.post(
         "/items/", json=test_item_1, headers=test_headers

--- a/tests/integration/v2/test_integration_item_types_v2.py
+++ b/tests/integration/v2/test_integration_item_types_v2.py
@@ -111,11 +111,14 @@ def test_get_item_type_invalid_api_key(client):
     assert response.status_code == 403
 
 
-def test_get_items_for_item_type_non_existing_id(client):
-    response = client.get(
-        "/item_types/" + str(non_existent_id) + "/items", headers=test_headers
-    )
+def test_get_item_type_not_found(client):
+    response = client.get("/item_types/" + str(non_existent_id), headers=test_headers)
     assert response.status_code == 404
+
+
+def test_get_item_type_invalid_id(client):
+    response = client.get("/item_types/invalidId", headers=test_headers)
+    assert response.status_code == 422
 
 
 def test_get_items_for_item_type_no_api_key(client):

--- a/tests/integration/v2/test_integration_locations_v2.py
+++ b/tests/integration/v2/test_integration_locations_v2.py
@@ -85,7 +85,7 @@ def test_get_location_invalid_api_key(client):
     assert response.status_code == 403
 
 
-def test_get_invalid_location_id(client):
+def test_get_non_existing_location_id(client):
     response = client.get("/locations/" + str(non_existent_id), headers=test_headers)
     assert response.status_code == 404
 

--- a/tests/integration/v2/test_integration_suppliers_v2.py
+++ b/tests/integration/v2/test_integration_suppliers_v2.py
@@ -161,6 +161,13 @@ def test_get_supplier_items_invalid_id(client):
     assert response.status_code == 422
 
 
+def test_get_supplier_items_non_existent_id(client):
+    response = client.get(
+        f'/suppliers/{str(non_existent_id)}/items', headers=test_headers
+    )
+    assert response.status_code == 404
+
+
 def test_get_supplier_items(client):
     response_post_fake_item_1 = client.post(
         "/items/", json=test_item_1, headers=test_headers


### PR DESCRIPTION
This pull request includes several changes to the integration tests for item groups, item lines, item types, locations, and suppliers. The main focus is on adding new test cases and removing redundant ones to ensure better coverage and accuracy.

### Integration Tests Enhancements:

* [`tests/integration/v2/test_integration_item_groups_v2.py`](diffhunk://#diff-49b519121eb4aebcae1e091aa1be90fc277a8bf4c6fd2d895d0867732d76f839L116-L127): Removed redundant test cases for getting items from item groups and added new test cases for deleting item groups with invalid or non-existent IDs. [[1]](diffhunk://#diff-49b519121eb4aebcae1e091aa1be90fc277a8bf4c6fd2d895d0867732d76f839L116-L127) [[2]](diffhunk://#diff-49b519121eb4aebcae1e091aa1be90fc277a8bf4c6fd2d895d0867732d76f839R288-R299)
* [`tests/integration/v2/test_integration_item_lines_v2.py`](diffhunk://#diff-81fad9d382f36ccb2933e91b06a539f06cab9b73e2bf3a028f02be5d7fd83975R155-R161): Added a new test case for getting items from an item line that does not exist.
* [`tests/integration/v2/test_integration_item_types_v2.py`](diffhunk://#diff-e6f310760497b45bbc07eb07bec9c7fb251eb99384456b93b8ee6075db80215dL114-R123): Replaced a test case for getting items for a non-existing item type with a test case for getting a non-existing item type, and added a new test case for getting an item type with an invalid ID.
* [`tests/integration/v2/test_integration_locations_v2.py`](diffhunk://#diff-e8a98b31eaa8e0dcfca0c223f6599bf0b198c0b134b430e0c59b0fc083edea64L88-R88): Renamed a test case to better reflect its purpose of testing a non-existing location ID.
* [`tests/integration/v2/test_integration_suppliers_v2.py`](diffhunk://#diff-db1b45c44dbac7ac2d43626870898dbeacb52618b690ad366915a3ec5e9eb906R164-R170): Added a new test case for getting items from a supplier with a non-existent ID.