### PR TITLE
Refactor primary key handling in DatabaseService to check for 'id' be…

### DIFF
--- a/app/services/database_service.py
+++ b/app/services/database_service.py
@@ -101,9 +101,9 @@ class DatabaseService:
         with self.get_connection_without_close() as conn:
             cursor = conn.execute(insert_sql, values)
 
-            inserted_id = cursor.lastrowid
-
-            setattr(model, primary_key_field, inserted_id)
+            if primary_key_field == "id":
+                inserted_id = cursor.lastrowid
+                setattr(model, primary_key_field, inserted_id)
 
         if closeConnection:
             self.commit_and_close()


### PR DESCRIPTION
This pull request includes a small change to the `insert` method in the `app/services/database_service.py` file. The change ensures that the primary key field is checked before setting the inserted ID.

* [`app/services/database_service.py`](diffhunk://#diff-9c2b18b0070cf3a0f1af611cc0f13e722f9bc3561339e7699241620db97ee260R104-L105): Added a condition to check if the `primary_key_field` is "id" before setting the `inserted_id`.