### PR TITLE
275 Change error status codes for archived warehouse operations to 400 + added test for editing archived warehouse

### DIFF
--- a/app/api/v2/endpoints/warehouse.py
+++ b/app/api/v2/endpoints/warehouse.py
@@ -94,13 +94,17 @@ def partial_update_warehouse(
     api_key: str = Depends(auth_provider_v2.get_api_key),
 ):
     data_provider_v2.init()
-    existing_warehouse = data_provider_v2.fetch_warehouse_pool().get_warehouse(
+    existing_warehouse = data_provider_v2.fetch_warehouse_pool().is_warehouse_archived(
         warehouse_id
     )
     if existing_warehouse is None:
         raise HTTPException(status_code=404, detail="Warehouse not found")
-    elif existing_warehouse.is_archived:
+    elif existing_warehouse:
         raise HTTPException(status_code=400, detail="Warehouse is archived")
+
+    existing_warehouse = data_provider_v2.fetch_warehouse_pool().get_warehouse(
+        warehouse_id
+    )
 
     for key, value in warehouse.items():
         setattr(existing_warehouse, key, value)

--- a/tests/v2/integration/test_integration_warehouses_v2.py
+++ b/tests/v2/integration/test_integration_warehouses_v2.py
@@ -361,3 +361,13 @@ def test_update_archived_warehouse(client):
         headers=test_headers,
     )
     assert response.status_code == 400
+
+
+def test_partial_update_archived_warehouse(client):
+    updated_warehouse = {"name": "Updated Warehouse"}
+    response = client.patch(
+        "/warehouses/" + str(test_warehouse["id"]),
+        json=updated_warehouse,
+        headers=test_headers,
+    )
+    assert response.status_code == 400


### PR DESCRIPTION
This pull request includes several changes to the `warehouse.py` endpoint and its related integration tests. The main focus of these changes is to update the HTTP status codes returned for various conditions when interacting with warehouse data.

### Endpoint Updates:

* [`app/api/v2/endpoints/warehouse.py`](diffhunk://#diff-99cace830bed11740be0d74c4c5b17f6e5fe11506431dd2e7672bd0307ca3d8aL83-R83): Changed the HTTP status code from 404 to 400 for cases where a warehouse is archived, already archived, or already unarchived. This affects the `update_warehouse`, `partial_update_warehouse`, `archive_warehouse`, and `unarchive_warehouse` functions. [[1]](diffhunk://#diff-99cace830bed11740be0d74c4c5b17f6e5fe11506431dd2e7672bd0307ca3d8aL83-R83) [[2]](diffhunk://#diff-99cace830bed11740be0d74c4c5b17f6e5fe11506431dd2e7672bd0307ca3d8aL103-R103) [[3]](diffhunk://#diff-99cace830bed11740be0d74c4c5b17f6e5fe11506431dd2e7672bd0307ca3d8aL127-R127) [[4]](diffhunk://#diff-99cace830bed11740be0d74c4c5b17f6e5fe11506431dd2e7672bd0307ca3d8aL144-R144)

### Integration Test Updates:

* [`tests/v2/integration/test_integration_warehouses_v2.py`](diffhunk://#diff-79e2df0705b19bc1eb65236fe9b12d763a67b3ad3747709e7d738ae5d3804411L341-R341): Updated the tests to assert the new 400 status code instead of 404 for the relevant conditions. Added a new test `test_update_archived_warehouse` to ensure that updating an archived warehouse returns a 400 status code. [[1]](diffhunk://#diff-79e2df0705b19bc1eb65236fe9b12d763a67b3ad3747709e7d738ae5d3804411L341-R341) [[2]](diffhunk://#diff-79e2df0705b19bc1eb65236fe9b12d763a67b3ad3747709e7d738ae5d3804411L352-R363)