### PR TITLE
Implement supplier archiving and unarchiving functionality with appropriate error handling

### DIFF
--- a/tests/v2/integration/test_integration_suppliers_v2.py
+++ b/tests/v2/integration/test_integration_suppliers_v2.py
@@ -328,7 +328,7 @@ def test_partial_update_supplier(client):
     assert response_get_supplier.json()["name"] == updated_supplier["name"]
 
 
-def test_delete_supplier_no_api_key(client):
+def test_archive_supplier_no_api_key(client):
     response = client.delete("/suppliers/" + str(test_supplier["id"]))
     assert response.status_code == 403
     response_get_supplier = client.get(
@@ -337,7 +337,7 @@ def test_delete_supplier_no_api_key(client):
     assert response_get_supplier.status_code == 200
 
 
-def test_delete_supplier_invalid_api_key(client):
+def test_archive_supplier_invalid_api_key(client):
     response = client.delete(
         "/suppliers/" + str(test_supplier["id"]), headers=invalid_headers
     )
@@ -348,12 +348,12 @@ def test_delete_supplier_invalid_api_key(client):
     assert response_get_supplier.status_code == 200
 
 
-def test_delete_supplier_invalid_id(client):
+def test_archive_supplier_invalid_id(client):
     response = client.delete("/suppliers/invalid_id", headers=test_headers)
     assert response.status_code == 422
 
 
-def test_delete_supplier_non_existent_id(client):
+def test_archive_supplier_non_existent_id(client):
     response = client.delete("/suppliers/" + str(non_existent_id), headers=test_headers)
     assert response.status_code == 404
     response_get_supplier = client.get(
@@ -362,11 +362,108 @@ def test_delete_supplier_non_existent_id(client):
     assert response_get_supplier.status_code == 200
 
 
-def test_delete_supplier(client):
+def test_archive_supplier(client):
     response = client.delete(
         "/suppliers/" + str(test_supplier["id"]), headers=test_headers
     )
     assert response.status_code == 200
+    response_get_supplier = client.get(
+        "/suppliers/" + str(test_supplier["id"]), headers=test_headers
+    )
+    assert response_get_supplier.status_code == 404
+
+
+def test_archive_already_archived_supplier(client):
+    reponse = client.delete(
+        "/suppliers/" + str(test_supplier["id"]), headers=test_headers
+    )
+    assert reponse.status_code == 400
+
+
+def test_unarchive_supplier(client):
+    response = client.patch(
+        "/suppliers/" + str(test_supplier["id"]) + "/unarchive",
+        json=test_supplier,
+        headers=test_headers,
+    )
+    assert response.status_code == 200
+    response_get_supplier = client.get(
+        "/suppliers/" + str(test_supplier["id"]), headers=test_headers
+    )
+    assert response_get_supplier.status_code == 200
+
+
+def test_unarchive_supplier_no_api_key(client):
+    response = client.patch("/suppliers/" + str(test_supplier["id"]) + "/unarchive")
+    assert response.status_code == 403
+
+
+def test_unarchive_supplier_invalid_api_key(client):
+    response = client.patch(
+        "/suppliers/" + str(test_supplier["id"]) + "/unarchive", headers=invalid_headers
+    )
+    assert response.status_code == 403
+
+
+def test_unarchive_supplier_invalid_id(client):
+    response = client.patch("/suppliers/invalid_id/unarchive", headers=test_headers)
+    assert response.status_code == 422
+
+
+def test_unarchive_supplier_non_existent_id(client):
+    response = client.patch(
+        "/suppliers/" + str(non_existent_id) + "/unarchive", headers=test_headers
+    )
+    assert response.status_code == 404
+
+
+def test_unarchive_supplier_already_unarchived(client):
+    response = client.patch(
+        "/suppliers/" + str(test_supplier["id"]) + "/unarchive", headers=test_headers
+    )
+    assert response.status_code == 400
+    response_get_supplier = client.get(
+        "/suppliers/" + str(test_supplier["id"]), headers=test_headers
+    )
+    assert response_get_supplier.status_code == 200
+    assert response_get_supplier.json()["is_archived"] == False
+
+
+def test_update_archived_supplier(client):
+    response_archive = client.delete(
+        "/suppliers/" + str(test_supplier["id"]), headers=test_headers
+    )
+    assert response_archive.status_code == 200
+
+    updated_supplier = test_supplier
+    updated_supplier["name"] = "Super coole nieuwe naam voor de test supplier"
+    response = client.put(
+        "/suppliers/" + str(updated_supplier["id"]),
+        json=updated_supplier,
+        headers=test_headers,
+    )
+    assert response.status_code == 400
+
+    response_get_supplier = client.get(
+        "/suppliers/" + str(updated_supplier["id"]), headers=test_headers
+    )
+    assert response_get_supplier.status_code == 404
+
+
+def test_partial_update_archived_supplier(client):
+    response_archive = client.delete(
+        "/suppliers/" + str(test_supplier["id"]), headers=test_headers
+    )
+    assert response_archive.status_code == 400
+
+    updated_supplier = {"name": "Super coole nieuwe naam voor de test supplier"}
+    response = client.patch(
+        "/suppliers/" + str(test_supplier["id"]),
+        json=updated_supplier,
+        headers=test_headers,
+    )
+    assert response.status_code == 400
+
     response_get_supplier = client.get(
         "/suppliers/" + str(test_supplier["id"]), headers=test_headers
     )


### PR DESCRIPTION
This pull request introduces changes to the supplier management system, focusing on adding functionality for archiving and unarchiving suppliers, and updating related endpoints and tests. The most important changes include modifying supplier update and partial update endpoints, adding archive and unarchive endpoints, and updating the supplier service and tests to support these new features.

### Supplier Endpoint Updates:
* [`app/api/v2/endpoints/supplier.py`](diffhunk://#diff-848be95957583fd0bf08e353e28a30cb63b82140fc36aa5b22f2a8d1ee9d2293L76-R82): Modified `update_supplier` and `partial_update_supplier` to check if a supplier is archived before proceeding with updates. Added new endpoints for archiving and unarchiving suppliers. [[1]](diffhunk://#diff-848be95957583fd0bf08e353e28a30cb63b82140fc36aa5b22f2a8d1ee9d2293L76-R82) [[2]](diffhunk://#diff-848be95957583fd0bf08e353e28a30cb63b82140fc36aa5b22f2a8d1ee9d2293L92-R104) [[3]](diffhunk://#diff-848be95957583fd0bf08e353e28a30cb63b82140fc36aa5b22f2a8d1ee9d2293L109-R150)

### Supplier Service Updates:
* [`app/services/v2/model_services/suppliers_service.py`](diffhunk://#diff-93b70403e12d78907ee76797d9224b47cdc615bfec4beee49855424fac2f71eeL13-R27): Added methods `archive_supplier`, `unarchive_supplier`, and `is_supplier_archived`. Modified existing methods to respect the archived status of suppliers. [[1]](diffhunk://#diff-93b70403e12d78907ee76797d9224b47cdc615bfec4beee49855424fac2f71eeL13-R27) [[2]](diffhunk://#diff-93b70403e12d78907ee76797d9224b47cdc615bfec4beee49855424fac2f71eeR42-R84)

### Test Updates:
* [`tests/v2/integration/test_integration_suppliers_v2.py`](diffhunk://#diff-533edff75d53f105f04051da09075b5b31d69de44dfb08003b0dd666bc791403L331-R331): Updated existing tests to reflect the new archive functionality and added new tests for archiving and unarchiving suppliers. [[1]](diffhunk://#diff-533edff75d53f105f04051da09075b5b31d69de44dfb08003b0dd666bc791403L331-R331) [[2]](diffhunk://#diff-533edff75d53f105f04051da09075b5b31d69de44dfb08003b0dd666bc791403L340-R340) [[3]](diffhunk://#diff-533edff75d53f105f04051da09075b5b31d69de44dfb08003b0dd666bc791403L351-R356) [[4]](diffhunk://#diff-533edff75d53f105f04051da09075b5b31d69de44dfb08003b0dd666bc791403L365-R365) [[5]](diffhunk://#diff-533edff75d53f105f04051da09075b5b31d69de44dfb08003b0dd666bc791403R374-R470)