### PR TITLE
Fix syntax errors in GitHub Actions workflow for status evaluation

### DIFF
--- a/.github/workflows/pr-prod.yml
+++ b/.github/workflows/pr-prod.yml
@@ -94,11 +94,11 @@ jobs:
 
           if [[ "${{ needs.test.result }}" == "cancelled" ]]; then
             echo "status=cancelled" >> $GITHUB_ENV
-          elif [[ "${{ needs.smoke.result }} == "cancelled" ]]; then
+          elif [[ "${{ needs.smoke.result }}" == "cancelled" ]]; then
             echo "status=cancelled" >> $GITHUB_ENV
           elif [[ "${{ needs.test.result }}" == "failure" ]]; then
             echo "status=failure" >> $GITHUB_ENV
-          elif [[ "${{ needs.smoke.result}}" == "failure" ]]; then
+          elif [[ "${{ needs.smoke.result }}" == "failure" ]]; then
             echo "status=failure" >> $GITHUB_ENV
           else
             echo "status=success" >> $GITHUB_ENV


### PR DESCRIPTION
This pull request includes a small but important fix to the `.github/workflows/pr-prod.yml` file. The change corrects a syntax error in the conditional statement that checks the status of the smoke tests.

* [`.github/workflows/pr-prod.yml`](diffhunk://#diff-460f57e51fd3d9536d8b73f5ffdf8618ed4053c3dc7f266960508a00a765cb6cL97-R97): Corrected the syntax error in the conditional statement to properly check if the smoke test result is "cancelled".