### PR TITLE
Refactor base model classes to support archiving functionality across…

### DIFF
--- a/app/models/v2/ItemInObject.py
+++ b/app/models/v2/ItemInObject.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel
-from models.v2.base import Base1
+from models.v2.base import Base
 
 
-class ItemInObject(Base1):
+class ItemInObject(Base):
     item_id: str
     amount: int

--- a/app/models/v2/base.py
+++ b/app/models/v2/base.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel
 
 
-class Base1(BaseModel):
+class Base(BaseModel):
     class Config:
         table_name: str | None = None
 
@@ -10,5 +10,5 @@ class Base1(BaseModel):
         return cls.Config.table_name or cls.__name__.lower() + "s"
 
 
-class Base2(Base1):
+class BaseWithArchived(Base):
     is_archived: bool = False

--- a/app/models/v2/client.py
+++ b/app/models/v2/client.py
@@ -1,7 +1,7 @@
-from models.v2.base import Base2
+from models.v2.base import BaseWithArchived
 
 
-class Client(Base2):
+class Client(BaseWithArchived):
     id: int | None = None
     name: str
     address: str

--- a/app/models/v2/endpoint_access.py
+++ b/app/models/v2/endpoint_access.py
@@ -1,7 +1,7 @@
-from .base import Base1
+from .base import Base
 
 
-class EndpointAccess(Base1):
+class EndpointAccess(Base):
     class Config:
         table_name = "endpoint_access"
 

--- a/app/models/v2/inventory.py
+++ b/app/models/v2/inventory.py
@@ -1,8 +1,8 @@
 from typing import List
-from models.v2.base import Base2
+from models.v2.base import BaseWithArchived
 
 
-class Inventory(Base2):
+class Inventory(BaseWithArchived):
     class Config:
         table_name = "inventories"
 

--- a/app/models/v2/item.py
+++ b/app/models/v2/item.py
@@ -1,8 +1,8 @@
 from pydantic import ConfigDict
-from models.v2.base import Base2
+from models.v2.base import BaseWithArchived
 
 
-class Item(Base2):
+class Item(BaseWithArchived):
     uid: str | None = None
     code: str
     description: str

--- a/app/models/v2/item_group.py
+++ b/app/models/v2/item_group.py
@@ -1,7 +1,7 @@
-from models.v2.base import Base2
+from models.v2.base import BaseWithArchived
 
 
-class ItemGroup(Base2):
+class ItemGroup(BaseWithArchived):
     id: int | None = None
     name: str
     description: str

--- a/app/models/v2/item_line.py
+++ b/app/models/v2/item_line.py
@@ -1,7 +1,7 @@
-from models.v2.base import Base2
+from models.v2.base import BaseWithArchived
 
 
-class ItemLine(Base2):
+class ItemLine(BaseWithArchived):
     id: int | None = None
     name: str
     description: str

--- a/app/models/v2/item_type.py
+++ b/app/models/v2/item_type.py
@@ -1,7 +1,7 @@
-from models.v2.base import Base2
+from models.v2.base import BaseWithArchived
 
 
-class ItemType(Base2):
+class ItemType(BaseWithArchived):
     id: int | None = None
     name: str
     description: str

--- a/app/models/v2/location.py
+++ b/app/models/v2/location.py
@@ -1,7 +1,7 @@
-from models.v2.base import Base2
+from models.v2.base import BaseWithArchived
 
 
-class Location(Base2):
+class Location(BaseWithArchived):
     id: int | None = None
     warehouse_id: int
     code: str

--- a/app/models/v2/order.py
+++ b/app/models/v2/order.py
@@ -1,8 +1,8 @@
 from .ItemInObject import ItemInObject
-from models.v2.base import Base2
+from models.v2.base import BaseWithArchived
 
 
-class Order(Base2):
+class Order(BaseWithArchived):
     id: int | None = None
     source_id: int
     order_date: str

--- a/app/models/v2/shipment.py
+++ b/app/models/v2/shipment.py
@@ -1,8 +1,8 @@
-from models.v2.base import Base2
+from models.v2.base import BaseWithArchived
 from models.v2.ItemInObject import ItemInObject
 
 
-class Shipment(Base2):
+class Shipment(BaseWithArchived):
     id: int | None = None
     order_id: int
     source_id: int

--- a/app/models/v2/supplier.py
+++ b/app/models/v2/supplier.py
@@ -1,7 +1,7 @@
-from models.v2.base import Base2
+from models.v2.base import BaseWithArchived
 
 
-class Supplier(Base2):
+class Supplier(BaseWithArchived):
     id: int | None = None
     code: str
     name: str

--- a/app/models/v2/transfer.py
+++ b/app/models/v2/transfer.py
@@ -1,8 +1,8 @@
-from models.v2.base import Base2
+from models.v2.base import BaseWithArchived
 from models.v2.ItemInObject import ItemInObject
 
 
-class Transfer(Base2):
+class Transfer(BaseWithArchived):
     id: int | None = None
     reference: str
     transfer_from: int | None = None

--- a/app/models/v2/user.py
+++ b/app/models/v2/user.py
@@ -1,9 +1,9 @@
 from typing import List
-from .base import Base2
+from .base import BaseWithArchived
 from .endpoint_access import EndpointAccess
 
 
-class User(Base2):
+class User(BaseWithArchived):
     id: int | None = None
     api_key: str
     app: str

--- a/app/models/v2/warehouse.py
+++ b/app/models/v2/warehouse.py
@@ -1,8 +1,8 @@
 from pydantic import EmailStr
-from models.v2.base import Base2
+from models.v2.base import BaseWithArchived
 
 
-class Warehouse(Base2):
+class Warehouse(BaseWithArchived):
     class Config:
         table_name = "warehouses"
 


### PR DESCRIPTION
This pull request includes changes to the `app/models/v2` directory to simplify the codebase by renaming classes and updating their inheritance structure. The most important changes include renaming `Base1` to `Base`, `Base2` to `BaseWithArchived`, and updating all affected model classes to inherit from the new base classes.

Class renaming and inheritance updates:

* [`app/models/v2/base.py`](diffhunk://#diff-7b1669d24ce5de5302afbdd133fa9df3c10e0957b8c6ec103456eabdeea486fcL4-R4): Renamed `Base1` to `Base` and `Base2` to `BaseWithArchived`. Updated the `table_name` method to reflect these changes. [[1]](diffhunk://#diff-7b1669d24ce5de5302afbdd133fa9df3c10e0957b8c6ec103456eabdeea486fcL4-R4) [[2]](diffhunk://#diff-7b1669d24ce5de5302afbdd133fa9df3c10e0957b8c6ec103456eabdeea486fcL13-R13)
* [`app/models/v2/ItemInObject.py`](diffhunk://#diff-997242af3fe33abbecec705e3c7c9c8d5af14b06199972fb6729917c60b868b1L2-R5): Updated `ItemInObject` to inherit from `Base` instead of `Base1`.
* [`app/models/v2/client.py`](diffhunk://#diff-7d17c234e9563b58b3a9e3146512cdf3175b7ef1c915cd98a68aa576c08eea57L1-R4): Updated `Client` to inherit from `BaseWithArchived` instead of `Base2`.
* [`app/models/v2/endpoint_access.py`](diffhunk://#diff-f9695b630728c527f33158ef4f2559b7e974e94d1148c2daf439d3cca314b60bL1-R4): Updated `EndpointAccess` to inherit from `Base` instead of `Base1`.
* Updated inheritance for remaining model classes to use `BaseWithArchived` instead of `Base2`:
  * `app/models/v2/inventory.py`
  * `app/models/v2/item.py`
  * `app/models/v2/item_group.py`
  * `app/models/v2/item_line.py`
  * `app/models/v2/item_type.py`
  * `app/models/v2/location.py`
  * `app/models/v2/order.py`
  * `app/models/v2/shipment.py`
  * `app/models/v2/supplier.py`
  * `app/models/v2/transfer.py`
  * `app/models/v2/user.py`
  * `app/models/v2/warehouse.py`