### PR TITLE
Pr test run should only run v2

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Test with pytest
         id: test_step
         run: |
-          coverage run -m pytest ./tests
+          coverage run -m pytest ./tests/v2
       - name: Run code coverage
         run: |
           coverage report -m --rcfile=.coveragerc --format=markdown >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/pr-test.yml` file. The change modifies the path for running pytest to the `./tests/v2` directory.

* [`.github/workflows/pr-test.yml`](diffhunk://#diff-cf34a98fd25d1698b625c9a988868d4cef5036692a76d1e28dc5aa42be237b9eL91-R91): Changed the pytest command to run tests in the `./tests/v2` directory instead of the `./tests` directory.