### PR TITLE
Rename test functions to fix duplication in transfer service tests

### DIFF
--- a/tests/v2/unit/test_unit_transfer_service_v2.py
+++ b/tests/v2/unit/test_unit_transfer_service_v2.py
@@ -300,7 +300,7 @@ def test_update_transfer_archived_item(
     assert result is None
 
 
-def test_update_transfer_archived_warehouse(
+def test_update_transfer_archived_warehouse_transfer_from(
     transfer_service, mock_db_service, mock_get_connection, mock_pools
 ):
 
@@ -320,7 +320,7 @@ def test_update_transfer_archived_warehouse(
     assert result is None
 
 
-def test_update_transfer_archived_warehouse(
+def test_update_transfer_archived_warehouse_transfer_to(
     transfer_service, mock_db_service, mock_get_connection, mock_pools
 ):
 


### PR DESCRIPTION
This pull request includes changes to the `tests/v2/unit/test_unit_transfer_service_v2.py` file to improve the clarity of test function names.

Improvements to test function names:

* [`tests/v2/unit/test_unit_transfer_service_v2.py`](diffhunk://#diff-c8085bb5cd0579acd1977d53f6e81bb1ee530f14e858b55f565e7f2be055106fL303-R303): Renamed `test_update_transfer_archived_warehouse` to `test_update_transfer_archived_warehouse_transfer_from` to better reflect its purpose.
* [`tests/v2/unit/test_unit_transfer_service_v2.py`](diffhunk://#diff-c8085bb5cd0579acd1977d53f6e81bb1ee530f14e858b55f565e7f2be055106fL323-R323): Renamed `test_update_transfer_archived_warehouse` to `test_update_transfer_archived_warehouse_transfer_to` to better reflect its purpose.