### PR TITLE
Return updated transfer data after committing a transfer

### DIFF
--- a/app/api/v2/endpoints/transfer.py
+++ b/app/api/v2/endpoints/transfer.py
@@ -88,10 +88,10 @@ def commit_transfer(transfer_id: int):
     committed_transfer = data_provider_v2.fetch_transfer_pool().commit_transfer(
         transfer
     )
-    data_provider_v2.fetch_transfer_pool().update_transfer(
+    updated_transfer = data_provider_v2.fetch_transfer_pool().update_transfer(
         transfer_id, committed_transfer
     )
-    return {"message": "Transfer committed successfully"}
+    return updated_transfer
 
 
 @transfer_router_v2.delete("/{transfer_id}")


### PR DESCRIPTION
This pull request includes a small but important change to the `commit_transfer` function in the `app/api/v2/endpoints/transfer.py` file. The change involves updating the return value of the function to return the updated transfer object instead of a success message.

* [`app/api/v2/endpoints/transfer.py`](diffhunk://#diff-e6bca7bf4ee8e45139805fb26cb7a4698e05e84efaa24774f3c827b0ff4039b6L91-R94): Modified `commit_transfer` function to return the updated transfer object instead of a success message.